### PR TITLE
Add supervised learning docs with regression models

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -53,6 +53,14 @@
             ]
           },
           {
+            "group": "Supervised Learning",
+            "pages": [
+              "machine-learning/supervised/index",
+              "machine-learning/supervised/linear-regression",
+              "machine-learning/supervised/logistic-regression"
+            ]
+          },
+          {
             "group": "Customization",
             "pages": [
               "essentials/settings",

--- a/machine-learning/supervised/index.mdx
+++ b/machine-learning/supervised/index.mdx
@@ -1,0 +1,15 @@
+---
+title: "Supervised Learning"
+description: "Overview of supervised learning and key algorithms."
+---
+
+# 📘 Supervised Learning
+
+Supervised learning algorithms learn a mapping from inputs $x$ to outputs $y$ using labeled training data. Each example in the training set is a pair $(x^{(i)}, y^{(i)})$, and the goal is to learn a function $f(x)$ that generalizes to new unseen examples.
+
+## Common Algorithms
+
+- [Linear Regression](./linear-regression)
+- [Logistic Regression](./logistic-regression)
+
+These pages dive into the mathematics, intuition, and practical implementation of each method.

--- a/machine-learning/supervised/linear-regression.mdx
+++ b/machine-learning/supervised/linear-regression.mdx
@@ -1,0 +1,46 @@
+---
+title: "Linear Regression"
+description: "Predicting continuous values with linear models."
+---
+
+# 📈 Linear Regression
+
+Linear regression models the relationship between a dependent variable $y$ and one or more features $x_1, \dots, x_n$ by fitting a linear function.
+
+## Hypothesis
+
+For an input vector $\mathbf{x} = [1, x_1, \dots, x_n]^T$, the model predicts
+
+$$
+\hat{y} = \mathbf{x}^T \boldsymbol{\theta} = \theta_0 + \theta_1 x_1 + \cdots + \theta_n x_n.
+$$
+
+## Loss Function
+
+Parameters $\boldsymbol{\theta}$ are learned by minimizing the **mean squared error** (MSE):
+
+$$
+J(\boldsymbol{\theta}) = \frac{1}{m} \sum_{i=1}^{m} (\hat{y}^{(i)} - y^{(i)})^2.
+$$
+
+## Example (scikit-learn)
+
+```python
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+# toy dataset
+X = np.array([[1], [2], [3], [4]])
+y = np.array([2, 3, 3, 5])
+
+model = LinearRegression()
+model.fit(X, y)
+
+pred = model.predict([[5]])
+print(pred)
+```
+
+## Interpretation
+
+- Coefficients $\theta_j$ show how much the prediction changes per unit increase in feature $x_j$.
+- The model is fast and interpretable but assumes a linear relationship between features and target.

--- a/machine-learning/supervised/logistic-regression.mdx
+++ b/machine-learning/supervised/logistic-regression.mdx
@@ -1,0 +1,46 @@
+---
+title: "Logistic Regression"
+description: "Binary classification using the logistic function."
+---
+
+# 🔐 Logistic Regression
+
+Logistic regression is a linear model for **binary classification**. It estimates the probability that an input $\mathbf{x}$ belongs to the positive class.
+
+## Hypothesis
+
+The model applies the logistic (sigmoid) function to a linear combination of the inputs:
+
+$$
+h_{\boldsymbol{\theta}}(\mathbf{x}) = \sigma(\mathbf{x}^T\boldsymbol{\theta}) = \frac{1}{1 + e^{-\mathbf{x}^T\boldsymbol{\theta}}}.
+$$
+
+## Cost Function
+
+Parameters are learned by minimizing the **logistic loss**:
+
+$$
+J(\boldsymbol{\theta}) = -\frac{1}{m} \sum_{i=1}^m \big[ y^{(i)} \log h_{\boldsymbol{\theta}}(\mathbf{x}^{(i)}) + (1 - y^{(i)}) \log (1 - h_{\boldsymbol{\theta}}(\mathbf{x}^{(i)})) \big].
+$$
+
+## Example (scikit-learn)
+
+```python
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+X = np.array([[0], [1], [2], [3]])
+y = np.array([0, 0, 1, 1])
+
+model = LogisticRegression()
+model.fit(X, y)
+
+proba = model.predict_proba([[1.5]])
+print(proba)
+```
+
+## Interpretation
+
+- Outputs a probability between 0 and 1.
+- Decision boundary at $h_{\boldsymbol{\theta}}(\mathbf{x}) = 0.5$.
+- For multi-class problems, use **one-vs-rest** or a **softmax regression** extension.


### PR DESCRIPTION
## Summary
- add Supervised Learning section with index and algorithm pages
- document Linear Regression with math and scikit-learn example
- document Logistic Regression with equations and code
- expose new pages in docs navigation

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a17baf94408320ba3bff3514e5a219