### PR TITLE
Expand supervised learning docs with additional algorithms

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -53,6 +53,20 @@
             ]
           },
           {
+            "group": "Supervised Learning",
+            "pages": [
+              "machine-learning/supervised/index",
+              "machine-learning/supervised/linear-regression",
+              "machine-learning/supervised/logistic-regression",
+              "machine-learning/supervised/decision-tree",
+              "machine-learning/supervised/random-forest",
+              "machine-learning/supervised/svm",
+              "machine-learning/supervised/k-nearest-neighbors",
+              "machine-learning/supervised/naive-bayes",
+              "machine-learning/supervised/gradient-boosting"
+            ]
+          },
+          {
             "group": "Customization",
             "pages": [
               "essentials/settings",

--- a/images/supervised/decision-tree.svg
+++ b/images/supervised/decision-tree.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <line x1="32" y1="8" x2="16" y2="28" stroke="#92400e" stroke-width="2"/>
+  <line x1="32" y1="8" x2="48" y2="28" stroke="#92400e" stroke-width="2"/>
+  <line x1="16" y1="28" x2="8" y2="48" stroke="#92400e" stroke-width="2"/>
+  <line x1="16" y1="28" x2="24" y2="48" stroke="#92400e" stroke-width="2"/>
+  <line x1="48" y1="28" x2="40" y2="48" stroke="#92400e" stroke-width="2"/>
+  <line x1="48" y1="28" x2="56" y2="48" stroke="#92400e" stroke-width="2"/>
+  <circle cx="32" cy="8" r="4" fill="#4ade80"/>
+  <circle cx="16" cy="28" r="4" fill="#4ade80"/>
+  <circle cx="48" cy="28" r="4" fill="#4ade80"/>
+  <circle cx="8" cy="48" r="4" fill="#4ade80"/>
+  <circle cx="24" cy="48" r="4" fill="#4ade80"/>
+  <circle cx="40" cy="48" r="4" fill="#4ade80"/>
+  <circle cx="56" cy="48" r="4" fill="#4ade80"/>
+</svg>

--- a/images/supervised/gradient-boosting.svg
+++ b/images/supervised/gradient-boosting.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(4,12)">
+    <line x1="12" y1="0" x2="4" y2="16" stroke="#92400e" stroke-width="2"/>
+    <line x1="12" y1="0" x2="20" y2="16" stroke="#92400e" stroke-width="2"/>
+    <circle cx="12" cy="0" r="4" fill="#fbbf24"/>
+    <circle cx="4" cy="16" r="4" fill="#fbbf24"/>
+    <circle cx="20" cy="16" r="4" fill="#fbbf24"/>
+  </g>
+  <text x="28" y="24" font-size="12" fill="#000">+</text>
+  <g transform="translate(36,12)">
+    <line x1="12" y1="0" x2="4" y2="16" stroke="#92400e" stroke-width="2"/>
+    <line x1="12" y1="0" x2="20" y2="16" stroke="#92400e" stroke-width="2"/>
+    <circle cx="12" cy="0" r="4" fill="#fbbf24"/>
+    <circle cx="4" cy="16" r="4" fill="#fbbf24"/>
+    <circle cx="20" cy="16" r="4" fill="#fbbf24"/>
+  </g>
+</svg>

--- a/images/supervised/knn.svg
+++ b/images/supervised/knn.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="3" fill="#3b82f6"/>
+  <circle cx="24" cy="28" r="3" fill="#3b82f6"/>
+  <circle cx="28" cy="18" r="3" fill="#3b82f6"/>
+  <circle cx="44" cy="40" r="3" fill="#ef4444"/>
+  <circle cx="40" cy="32" r="3" fill="#ef4444"/>
+  <circle cx="36" cy="44" r="3" fill="#ef4444"/>
+  <circle cx="34" cy="24" r="4" stroke="#22c55e" stroke-width="2" fill="none"/>
+  <line x1="34" y1="24" x2="44" y2="40" stroke="#22c55e" stroke-width="1"/>
+  <line x1="34" y1="24" x2="40" y2="32" stroke="#22c55e" stroke-width="1"/>
+  <line x1="34" y1="24" x2="36" y2="44" stroke="#22c55e" stroke-width="1"/>
+</svg>

--- a/images/supervised/linear-regression.svg
+++ b/images/supervised/linear-regression.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <line x1="8" y1="50" x2="56" y2="14" stroke="#f87171" stroke-width="2"/>
+  <circle cx="12" cy="48" r="3" fill="#60a5fa"/>
+  <circle cx="20" cy="44" r="3" fill="#60a5fa"/>
+  <circle cx="28" cy="40" r="3" fill="#60a5fa"/>
+  <circle cx="36" cy="34" r="3" fill="#60a5fa"/>
+  <circle cx="44" cy="28" r="3" fill="#60a5fa"/>
+</svg>

--- a/images/supervised/logistic-regression.svg
+++ b/images/supervised/logistic-regression.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 56 C24 56, 40 8, 56 8" stroke="#10b981" stroke-width="2" fill="none"/>
+</svg>

--- a/images/supervised/naive-bayes.svg
+++ b/images/supervised/naive-bayes.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8 40 Q16 16 24 40" stroke="#3b82f6" stroke-width="2" fill="none"/>
+  <path d="M40 40 Q48 16 56 40" stroke="#ef4444" stroke-width="2" fill="none"/>
+</svg>

--- a/images/supervised/random-forest.svg
+++ b/images/supervised/random-forest.svg
@@ -1,0 +1,23 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(4,0)">
+    <line x1="12" y1="8" x2="4" y2="24" stroke="#92400e" stroke-width="2"/>
+    <line x1="12" y1="8" x2="20" y2="24" stroke="#92400e" stroke-width="2"/>
+    <circle cx="12" cy="8" r="4" fill="#4ade80"/>
+    <circle cx="4" cy="24" r="4" fill="#4ade80"/>
+    <circle cx="20" cy="24" r="4" fill="#4ade80"/>
+  </g>
+  <g transform="translate(24,8)">
+    <line x1="12" y1="8" x2="4" y2="24" stroke="#92400e" stroke-width="2"/>
+    <line x1="12" y1="8" x2="20" y2="24" stroke="#92400e" stroke-width="2"/>
+    <circle cx="12" cy="8" r="4" fill="#4ade80"/>
+    <circle cx="4" cy="24" r="4" fill="#4ade80"/>
+    <circle cx="20" cy="24" r="4" fill="#4ade80"/>
+  </g>
+  <g transform="translate(44,0)">
+    <line x1="12" y1="8" x2="4" y2="24" stroke="#92400e" stroke-width="2"/>
+    <line x1="12" y1="8" x2="20" y2="24" stroke="#92400e" stroke-width="2"/>
+    <circle cx="12" cy="8" r="4" fill="#4ade80"/>
+    <circle cx="4" cy="24" r="4" fill="#4ade80"/>
+    <circle cx="20" cy="24" r="4" fill="#4ade80"/>
+  </g>
+</svg>

--- a/images/supervised/svm.svg
+++ b/images/supervised/svm.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <line x1="8" y1="40" x2="56" y2="24" stroke="#000" stroke-width="2"/>
+  <line x1="8" y1="44" x2="56" y2="28" stroke="#9ca3af" stroke-dasharray="4" stroke-width="1"/>
+  <line x1="8" y1="36" x2="56" y2="20" stroke="#9ca3af" stroke-dasharray="4" stroke-width="1"/>
+  <circle cx="16" cy="46" r="3" fill="#3b82f6"/>
+  <circle cx="20" cy="42" r="3" fill="#3b82f6"/>
+  <circle cx="24" cy="38" r="3" fill="#3b82f6"/>
+  <circle cx="40" cy="28" r="3" fill="#ef4444"/>
+  <circle cx="44" cy="24" r="3" fill="#ef4444"/>
+  <circle cx="48" cy="20" r="3" fill="#ef4444"/>
+</svg>

--- a/machine-learning/supervised/decision-tree.mdx
+++ b/machine-learning/supervised/decision-tree.mdx
@@ -1,0 +1,41 @@
+---
+title: "Decision Tree"
+description: "Tree-based model for classification and regression."
+---
+
+# 🌳 Decision Tree
+
+<img src="../../images/supervised/decision-tree.svg" alt="Decision tree icon" width="80" />
+
+Decision trees split data into regions based on feature values, forming a tree where each leaf gives a prediction.
+
+## Mathematics
+
+For classification, splits are chosen to maximize **information gain**. Using Gini impurity:
+
+$$
+G = \sum_{k=1}^K p_k (1 - p_k),
+$$
+
+where $p_k$ is the proportion of class $k$ in a node.
+
+## Example (scikit-learn)
+
+```python
+from sklearn.datasets import load_iris
+from sklearn.tree import DecisionTreeClassifier
+
+X, y = load_iris(return_X_y=True)
+model = DecisionTreeClassifier(max_depth=3)
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Predicting customer churn based on usage statistics.
+
+## Recommendations
+
+- Easy to interpret; visualize the tree for insights.
+- Prone to overfitting; limit depth or prune.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/tree.html#classification) for more.

--- a/machine-learning/supervised/gradient-boosting.mdx
+++ b/machine-learning/supervised/gradient-boosting.mdx
@@ -1,0 +1,39 @@
+---
+title: "Gradient Boosting"
+description: "Sequential ensemble that minimizes loss via gradients."
+---
+
+# 🚀 Gradient Boosting
+
+<img src="../../images/supervised/gradient-boosting.svg" alt="Gradient boosting icon" width="80" />
+
+Gradient boosting builds models sequentially, each new model correcting the errors of the combined previous ones.
+
+## Mathematics
+
+At each stage $m$, fit a model $h_m(x)$ to the negative gradient of the loss function:
+
+$$
+F_m(x) = F_{m-1}(x) + \nu h_m(x).
+$$
+
+## Example (scikit-learn)
+
+```python
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import GradientBoostingRegressor
+
+X, y = load_diabetes(return_X_y=True)
+model = GradientBoostingRegressor()
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Predicting insurance claim amounts with complex feature interactions.
+
+## Recommendations
+
+- Sensitive to hyperparameters like learning rate and number of estimators.
+- Use early stopping or a validation set to avoid overfitting.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/ensemble.html#gradient-tree-boosting) for more.

--- a/machine-learning/supervised/index.mdx
+++ b/machine-learning/supervised/index.mdx
@@ -1,0 +1,22 @@
+---
+title: "Supervised Learning"
+description: "Overview of supervised learning and key algorithms."
+---
+
+# 📘 Supervised Learning
+
+Supervised learning algorithms learn a mapping from inputs $x$ to outputs $y$ using labeled training data. Each example in the training set is a pair $(x^{(i)}, y^{(i)})$, and the goal is to learn a function $f(x)$ that generalizes to new unseen examples.
+
+## Common Algorithms
+
+- [Linear Regression](./linear-regression)
+- [Logistic Regression](./logistic-regression)
+
+- [Decision Tree](./decision-tree)
+- [Random Forest](./random-forest)
+- [Support Vector Machine](./svm)
+- [k-Nearest Neighbors](./k-nearest-neighbors)
+- [Naive Bayes](./naive-bayes)
+- [Gradient Boosting](./gradient-boosting)
+
+These pages dive into the mathematics, intuition, and practical implementation of each method.

--- a/machine-learning/supervised/k-nearest-neighbors.mdx
+++ b/machine-learning/supervised/k-nearest-neighbors.mdx
@@ -1,0 +1,41 @@
+---
+title: "k-Nearest Neighbors"
+description: "Instance-based learning using neighbor votes."
+---
+
+# 🤝 k-Nearest Neighbors
+
+<img src="../../images/supervised/knn.svg" alt="k-NN icon" width="80" />
+
+k-NN classifies a point by the majority label of its $k$ closest examples.
+
+## Mathematics
+
+Given a distance metric $d$, predict
+
+$$
+\hat{y} = \operatorname{mode}(y_i \text{ for } i \in N_k(x)),
+$$
+
+where $N_k(x)$ are the indices of the $k$ nearest neighbors of $x$.
+
+## Example (scikit-learn)
+
+```python
+from sklearn.datasets import load_iris
+from sklearn.neighbors import KNeighborsClassifier
+
+X, y = load_iris(return_X_y=True)
+model = KNeighborsClassifier(n_neighbors=3)
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Recommending products based on similar users.
+
+## Recommendations
+
+- Choose $k$ via cross-validation.
+- Scale features for Euclidean distance.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/neighbors.html) for more.

--- a/machine-learning/supervised/linear-regression.mdx
+++ b/machine-learning/supervised/linear-regression.mdx
@@ -1,0 +1,58 @@
+---
+title: "Linear Regression"
+description: "Predicting continuous values with linear models."
+---
+
+# 📈 Linear Regression
+
+<img src="../../images/supervised/linear-regression.svg" alt="Linear regression icon" width="80" />
+
+Linear regression models the relationship between a dependent variable $y$ and one or more features $x_1, \dots, x_n$ by fitting a linear function.
+
+## Hypothesis
+
+For an input vector $\mathbf{x} = [1, x_1, \dots, x_n]^T$, the model predicts
+
+$$
+\hat{y} = \mathbf{x}^T \boldsymbol{\theta} = \theta_0 + \theta_1 x_1 + \cdots + \theta_n x_n.
+$$
+
+## Loss Function
+
+Parameters $\boldsymbol{\theta}$ are learned by minimizing the **mean squared error** (MSE):
+
+$$
+J(\boldsymbol{\theta}) = \frac{1}{m} \sum_{i=1}^{m} (\hat{y}^{(i)} - y^{(i)})^2.
+$$
+
+## Example (scikit-learn)
+
+```python
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+# toy dataset
+X = np.array([[1], [2], [3], [4]])
+y = np.array([2, 3, 3, 5])
+
+model = LinearRegression()
+model.fit(X, y)
+
+pred = model.predict([[5]])
+print(pred)
+```
+
+## Use Case Example
+
+Predicting house prices from features like square footage and number of rooms.
+
+## Recommendations
+
+- Works well when the relationship between features and target is roughly linear.
+- Sensitive to outliers; consider preprocessing or robust regression if needed.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/linear_model.html#ordinary-least-squares) for more details.
+
+## Interpretation
+
+- Coefficients $\theta_j$ show how much the prediction changes per unit increase in feature $x_j$.
+- The model is fast and interpretable but assumes a linear relationship between features and target.

--- a/machine-learning/supervised/logistic-regression.mdx
+++ b/machine-learning/supervised/logistic-regression.mdx
@@ -1,0 +1,58 @@
+---
+title: "Logistic Regression"
+description: "Binary classification using the logistic function."
+---
+
+# 🔐 Logistic Regression
+
+<img src="../../images/supervised/logistic-regression.svg" alt="Logistic regression icon" width="80" />
+
+Logistic regression is a linear model for **binary classification**. It estimates the probability that an input $\mathbf{x}$ belongs to the positive class.
+
+## Hypothesis
+
+The model applies the logistic (sigmoid) function to a linear combination of the inputs:
+
+$$
+h_{\boldsymbol{\theta}}(\mathbf{x}) = \sigma(\mathbf{x}^T\boldsymbol{\theta}) = \frac{1}{1 + e^{-\mathbf{x}^T\boldsymbol{\theta}}}.
+$$
+
+## Cost Function
+
+Parameters are learned by minimizing the **logistic loss**:
+
+$$
+J(\boldsymbol{\theta}) = -\frac{1}{m} \sum_{i=1}^m \big[ y^{(i)} \log h_{\boldsymbol{\theta}}(\mathbf{x}^{(i)}) + (1 - y^{(i)})\log (1 - h_{\boldsymbol{\theta}}(\mathbf{x}^{(i)})) \big].
+$$
+
+## Example (scikit-learn)
+
+```python
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+X = np.array([[0], [1], [2], [3]])
+y = np.array([0, 0, 1, 1])
+
+model = LogisticRegression()
+model.fit(X, y)
+
+proba = model.predict_proba([[1.5]])
+print(proba)
+```
+
+## Use Case Example
+
+Email spam detection where emails are classified as spam or not spam.
+
+## Recommendations
+
+- Use when the dependent variable is binary.
+- Regularize with L1/L2 penalties to prevent overfitting.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression) for more details.
+
+## Interpretation
+
+- Outputs a probability between 0 and 1.
+- Decision boundary at $h_{\boldsymbol{\theta}}(\mathbf{x}) = 0.5$.
+- For multi-class problems, use **one-vs-rest** or a **softmax regression** extension.

--- a/machine-learning/supervised/naive-bayes.mdx
+++ b/machine-learning/supervised/naive-bayes.mdx
@@ -1,0 +1,37 @@
+---
+title: "Naive Bayes"
+description: "Probabilistic classifier assuming feature independence."
+---
+
+# 📊 Naive Bayes
+
+<img src="../../images/supervised/naive-bayes.svg" alt="Naive Bayes icon" width="80" />
+
+Naive Bayes uses Bayes' theorem with the assumption that features are conditionally independent given the class.
+
+## Mathematics
+
+$$
+P(y \mid x_1, \dots, x_n) \propto P(y) \prod_{j=1}^n P(x_j \mid y).
+$$
+
+## Example (scikit-learn)
+
+```python
+from sklearn.datasets import load_iris
+from sklearn.naive_bayes import GaussianNB
+
+X, y = load_iris(return_X_y=True)
+model = GaussianNB()
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Classifying news articles into topics.
+
+## Recommendations
+
+- Works well with high-dimensional data like text.
+- Assumes feature independence; may underperform if features correlate.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/naive_bayes.html) for more.

--- a/machine-learning/supervised/random-forest.mdx
+++ b/machine-learning/supervised/random-forest.mdx
@@ -1,0 +1,39 @@
+---
+title: "Random Forest"
+description: "Ensemble of decision trees for improved accuracy."
+---
+
+# 🌲 Random Forest
+
+<img src="../../images/supervised/random-forest.svg" alt="Random forest icon" width="80" />
+
+Random forests build many decision trees on bootstrapped datasets and average their predictions.
+
+## Mathematics
+
+For regression, the forest prediction is the average of individual tree outputs:
+
+$$
+\hat{y} = \frac{1}{T} \sum_{t=1}^T f_t(x).
+$$
+
+## Example (scikit-learn)
+
+```python
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import RandomForestRegressor
+
+X, y = load_diabetes(return_X_y=True)
+model = RandomForestRegressor(n_estimators=100)
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Forecasting house prices with diverse feature sets.
+
+## Recommendations
+
+- Handles nonlinearity and feature interactions well.
+- Use more trees for stability but watch computation time.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/ensemble.html#forest) for more.

--- a/machine-learning/supervised/svm.mdx
+++ b/machine-learning/supervised/svm.mdx
@@ -1,0 +1,39 @@
+---
+title: "Support Vector Machine"
+description: "Margin-based classifier using hyperplanes."
+---
+
+# ⚖️ Support Vector Machine
+
+<img src="../../images/supervised/svm.svg" alt="SVM icon" width="80" />
+
+SVMs find the hyperplane that maximizes the margin between classes.
+
+## Mathematics
+
+The primal optimization problem for a linear SVM is
+
+$$
+\min_{\mathbf{w}, b} \frac{1}{2}\lVert\mathbf{w}\rVert^2 + C\sum_{i=1}^m \xi_i \quad \text{s.t. } y^{(i)} (\mathbf{w}^T \mathbf{x}^{(i)} + b) \ge 1 - \xi_i.
+$$
+
+## Example (scikit-learn)
+
+```python
+from sklearn import svm
+from sklearn.datasets import make_classification
+
+X, y = make_classification(n_features=2, n_redundant=0)
+model = svm.SVC(kernel="linear")
+model.fit(X, y)
+```
+
+## Use Case Example
+
+Classifying handwritten digits with clear margins between classes.
+
+## Recommendations
+
+- Choose kernels (linear, RBF) based on data.
+- Scale features for better performance.
+- See the [scikit-learn guide](https://scikit-learn.org/stable/modules/svm.html) for more.


### PR DESCRIPTION
## Summary
- document Decision Tree, Random Forest, Support Vector Machine, k-Nearest Neighbors, Naive Bayes, and Gradient Boosting with icons, equations, code, and recommendations
- add icons and practical guidance to existing Linear and Logistic Regression pages
- expose all supervised learning pages in docs navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a17baf94408320ba3bff3514e5a219